### PR TITLE
Handle short input files correctly

### DIFF
--- a/zopfli/deflate.go
+++ b/zopfli/deflate.go
@@ -686,7 +686,11 @@ func (z *Deflator) Deflate(final bool, in []byte) (err error) {
 		}
 	}()
 
-	if MASTER_BLOCK_SIZE == 0 {
+	// Zero-length inputs must pass through z.DeflatePart
+	// at least once in order to be flushed correctly. On the
+	// other size of this if, the for loop is skipped entirely for
+	// len(in) == 0.
+	if MASTER_BLOCK_SIZE == 0 || len(in) == 0 {
 		err := z.DeflatePart(true, in, 0, len(in))
 		if err != nil {
 			return err

--- a/zopfli/lz77.go
+++ b/zopfli/lz77.go
@@ -39,7 +39,7 @@ type LZ77Store []lz77Pair
 // but is kept for easy future expansion.
 type BlockState struct {
 	options *Options
-	block []byte
+	block   []byte
 
 	// The start (inclusive) and end (not inclusive) of the current block.
 	blockStart, blockEnd int
@@ -371,8 +371,8 @@ func (s *BlockState) findLongestMatch(h *hash, slice []byte, pos, size int, limi
 // Does LZ77 using an algorithm similar to gzip, with lazy matching, rather than
 // with the slow but better "squeeze" implementation.
 // The result is placed in the LZ77Store.
-// If inStart is larger than 0, it uses values before inStart as starting
-// dictionary.
+// If inStart is larger than WINDOW_SIZE, it uses values before inStart
+// as a starting dictionary.
 func (s *BlockState) LZ77Greedy(inStart, inEnd int) (store LZ77Store) {
 	var windowStart int
 	if inStart > WINDOW_SIZE {
@@ -383,7 +383,7 @@ func (s *BlockState) LZ77Greedy(inStart, inEnd int) (store LZ77Store) {
 	var prevPair lz77Pair
 	var matchAvailable bool
 
-	if inStart == inEnd {
+	if windowStart+1 >= len(s.block) {
 		return
 	}
 

--- a/zopfli/zopfli_test.go
+++ b/zopfli/zopfli_test.go
@@ -1,0 +1,46 @@
+package zopfli
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"testing"
+)
+
+func TestIssue2(t *testing.T) {
+	tests := []struct {
+		in []byte
+	}{
+		// Issue 2.
+		{[]byte{}},
+		{[]byte{0}},
+		// Just test a bigger one too.
+		{make([]byte, 8192)},
+	}
+
+	opt := DefaultOptions()
+	//opt.Verbose = true
+	//opt.VerboseMore = true
+
+	buf := &bytes.Buffer{}
+	for _, tt := range tests {
+		err := GzipCompress(&opt, tt.in, buf)
+		if err != nil {
+			t.Fatal("fail to compress:", err)
+		}
+
+		zr, err := gzip.NewReader(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, err := ioutil.ReadAll(zr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(tt.in, out) {
+			t.Fatal("wanted %#v, got %#v", tt.in, out)
+		}
+		buf.Reset()
+		t.Logf("encode len %v ok", len(tt.in))
+	}
+}


### PR DESCRIPTION
Zero length files were not flushed correctly. Files of
length one failed because hash initialization required
2 bytes. In the one byte case, we skip the optimization
search and send back one literal instead.

Fixes #2